### PR TITLE
Remove podmonitor deprecated api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove pod monitor deprecated api.
+
 ## [0.1.1] - 2023-01-23
 
 ### Added

--- a/hack/additional-resources/podmonitor.yaml
+++ b/hack/additional-resources/podmonitor.yaml
@@ -10,4 +10,4 @@ spec:
     # filled by matchlabels-transformer.yaml
     matchLabels: {}
   podMetricsEndpoints:
-    - targetPort: http
+    - port: http

--- a/helm/caicloud-event-exporter-app/templates/install.yaml
+++ b/helm/caicloud-event-exporter-app/templates/install.yaml
@@ -99,7 +99,7 @@ spec:
     matchNames:
     - {{ .Release.Namespace }}
   podMetricsEndpoints:
-  - targetPort: http
+  - port: http
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
See:

level=warn ts=2023-05-10T08:27:07.326931139Z caller=promcfg.go:801 component=prometheusoperator msg="'targetPort' is deprecated, use 'port' instead." version=v2.43.0-stringlabels
level=warn ts=2023-05-10T08:27:07.32710136Z caller=promcfg.go:801 component=prometheusoperator msg="'targetPort' is deprecated, use 'port' instead." version=v2.43.0-stringlabels
