### PR TITLE
Replace icon

### DIFF
--- a/helm/caicloud-event-exporter-app/Chart.yaml
+++ b/helm/caicloud-event-exporter-app/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   then translated into metrics.
 engine: gotpl
 home: https://github.com/giantswarm/caicloud-event-exporter-app
-icon: https://s.giantswarm.io/app-icons/flux/1/dark.svg
+icon: https://s.giantswarm.io/app-icons/prometheus/1/light.svg
 keywords:
   - event-exporter
   - exporter


### PR DESCRIPTION
This sets the Prometheus icon, which we use for almost all Prometheus exporters. Previously the Flux logo was used, despite the app not being Flux specific.